### PR TITLE
Format all python code with yapf

### DIFF
--- a/c_org/cli/__init__.py
+++ b/c_org/cli/__init__.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from c_org.cli.core import Core
 
+
 def main():
     c_org = Core()
     c_org.main()

--- a/c_org/cli/command.py
+++ b/c_org/cli/command.py
@@ -14,7 +14,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 '''c_org command line'''
 
 import logging
@@ -24,9 +23,7 @@ import argparse
 import c_org.utils as utils
 
 
-
 class COrgCommand(argparse.Namespace):
-
     def __init__(self, command_id, description, testing=False, leaf=False):
         self.command_id = command_id
         self.description = description
@@ -40,31 +37,32 @@ class COrgCommand(argparse.Namespace):
         self.leaf_command = leaf
         self.commandclass = None
 
-        self.parser = argparse.ArgumentParser(prog="%s %s" % (sys.argv[0], command_id),
-                                              description=description,
-                                              add_help=True)
-        self.parser.add_argument('--debug', action='store_true',
-                                 help='Enable debug messages')
+        self.parser = argparse.ArgumentParser(
+            prog="%s %s" % (sys.argv[0], command_id),
+            description=description,
+            add_help=True)
+        self.parser.add_argument(
+            '--debug', action='store_true', help='Enable debug messages')
 
         if not leaf:
-            self.subparsers = self.parser.add_subparsers(title='Available commands',
-                                                         metavar='', dest='subcommand')
-            p_help = self.subparsers.add_parser('help',
-                                                description='Show this help message',
-                                                help='Show this help message')
+            self.subparsers = self.parser.add_subparsers(
+                title='Available commands', metavar='', dest='subcommand')
+            p_help = self.subparsers.add_parser(
+                'help',
+                description='Show this help message',
+                help='Show this help message')
             p_help.set_defaults(func=self.print_usage)
-
 
     def update(self, args):
         self._args = args
 
     def parse_args(self):
-        ns, self._args = self.parser.parse_known_args(args=self._args, namespace=self)
+        ns, self._args = self.parser.parse_known_args(
+            args=self._args, namespace=self)
 
         if not self.subcommand:
             print('You need to specify a command', file=sys.stderr)
             self.print_usage()
-
 
     def print_usage(self):
         self.parser.print_help(file=sys.stderr)
@@ -76,9 +74,7 @@ class COrgCommand(argparse.Namespace):
         unpickle = utils.restricted_unpickle()
         self.address = unpickle['address']
         self.abi = unpickle['abi']
-        self.contact = w3.eth.contract(address=self.address,
-                                       abi=self.abi)
-
+        self.contact = w3.eth.contract(address=self.address, abi=self.abi)
 
     def _add_subparser_from_class(self, name, commandclass):
         instance = commandclass()
@@ -91,13 +87,13 @@ class COrgCommand(argparse.Namespace):
             if not os.environ.get('ENABLE_TEST_COMMANDS', None):
                 return
 
-        p = self.subparsers.add_parser(instance.command_id,
-                                       description=instance.description,
-                                       help=instance.description,
-                                       add_help=False)
+        p = self.subparsers.add_parser(
+            instance.command_id,
+            description=instance.description,
+            help=instance.description,
+            add_help=False)
         p.set_defaults(func=instance.run, commandclass=instance)
         self.subcommands[name]['parser'] = p
-
 
     def _import_subcommands(self, submodules):
         import inspect

--- a/c_org/cli/commands/__init__.py
+++ b/c_org/cli/commands/__init__.py
@@ -24,11 +24,7 @@ from c_org.cli.commands.wallet import COrgWallet
 # from c_org.cli.commands.init import COrgInit
 
 __all__ = [
-    'COrgDeploy',
-    'COrgBuy',
-    'COrgSell',
-    'COrgRevenue',
-    'COrgStats',
+    'COrgDeploy', 'COrgBuy', 'COrgSell', 'COrgRevenue', 'COrgStats',
     'COrgWallet'
     # 'COrgInit'
 ]

--- a/c_org/cli/commands/buy.py
+++ b/c_org/cli/commands/buy.py
@@ -14,7 +14,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 '''c_org buy command line'''
 
 import logging
@@ -23,25 +22,21 @@ from c_org.cli.command import COrgCommand
 from c_org import ContinuousOrganisationManager
 from c_org.manager import Vault
 
-class COrgBuy(COrgCommand):
 
+class COrgBuy(COrgCommand):
     def __init__(self):
-        super().__init__(command_id='buy', leaf=True,
-                         description='Buy tokens')
+        super().__init__(command_id='buy', leaf=True, description='Buy tokens')
         self.subcommand = True
 
-
     def run(self):
-        self.parser.add_argument('--wallet',
-                                 help='Name of the sender\'s wallet',
-                                 type=str)
-        self.parser.add_argument('--amount',
-                                 help='Amount to send',
-                                 type=float)
-        self.parser.add_argument('name',
-                                 help='Continuous Organisation\'s name',
-                                 type=str,
-                                 metavar="name")
+        self.parser.add_argument(
+            '--wallet', help='Name of the sender\'s wallet', type=str)
+        self.parser.add_argument('--amount', help='Amount to send', type=float)
+        self.parser.add_argument(
+            'name',
+            help='Continuous Organisation\'s name',
+            type=str,
+            metavar="name")
         self.func = self.command_buy
         self.parse_args()
         self.run_command()
@@ -54,15 +49,20 @@ class COrgBuy(COrgCommand):
         try:
             wallet = vault.find_wallet(name=self.wallet)
         except ValueError:
-            return logging.error('The wallet is not recognized. Add a wallet with the wallet command.')
+            return logging.error(
+                'The wallet is not recognized. Add a wallet with the wallet command.'
+            )
 
         c_org_manager = ContinuousOrganisationManager(self.name)
         if not c_org_manager.is_built():
-            return logging.error('The continuous organisation is not deployed.  Run first `c-org deploy --help`.')
+            return logging.error(
+                'The continuous organisation is not deployed.  Run first `c-org deploy --help`.'
+            )
 
-        logging.debug('Buying an amount of {:.3f} to {}'.
-                       format(self.amount, self.name))
+        logging.debug('Buying an amount of {:.3f} to {}'.format(
+            self.amount, self.name))
         c_org_manager.buy(self.amount, wallet)
 
         balance = c_org_manager.get_balance(wallet)
-        logging.info("Great! Your buy tokens! Your balance is now {:d}".format(balance))
+        logging.info(
+            "Great! Your buy tokens! Your balance is now {:d}".format(balance))

--- a/c_org/cli/commands/deploy.py
+++ b/c_org/cli/commands/deploy.py
@@ -14,7 +14,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 '''c_org apply command line'''
 
 import logging
@@ -26,21 +25,20 @@ from c_org import ContinuousOrganisationManager
 import c_org.utils as utils
 from c_org.manager import Vault, GlobalParams, LocalParams
 
-class COrgDeploy(COrgCommand):
 
+class COrgDeploy(COrgCommand):
     def __init__(self):
-        super().__init__(command_id='deploy', leaf=True,
-                         description='Create a Continuous Organisation')
+        super().__init__(
+            command_id='deploy',
+            leaf=True,
+            description='Create a Continuous Organisation')
         self.subcommand = True
 
     def run(self):
-        self.parser.add_argument('output',
-                                 help='Path to config.yaml',
-                                 type=str,
-                                 metavar="path")
-        self.parser.add_argument('--wallet',
-                                  help='Name of the wallet',
-                                  type=str)
+        self.parser.add_argument(
+            'output', help='Path to config.yaml', type=str, metavar="path")
+        self.parser.add_argument(
+            '--wallet', help='Name of the wallet', type=str)
         self.func = self.command_deploy
         self.parse_args()
         self.run_command()
@@ -50,19 +48,25 @@ class COrgDeploy(COrgCommand):
             self.output = os.path.join(self.output, "config.yaml")
 
         if not os.path.isfile(self.output):
-            return logging.error('The path is not valid. Please add a path to the config.yaml file.')
+            return logging.error(
+                'The path is not valid. Please add a path to the config.yaml file.'
+            )
         dirname = os.path.dirname(os.path.abspath(self.output))
 
         if not self.wallet:
             try:
                 wallet = Vault().default_wallet()
             except ValueError:
-                return logging.error('No wallet has been specified. Please add option--wallet NAME, or add a wallet with the wallet command.')
+                return logging.error(
+                    'No wallet has been specified. Please add option--wallet NAME, or add a wallet with the wallet command.'
+                )
         else:
             try:
                 wallet = Vault().find_wallet(name=self.wallet)
             except ValueError:
-                return logging.error('The wallet is not recognized. Add a wallet with the wallet command.')
+                return logging.error(
+                    'The wallet is not recognized. Add a wallet with the wallet command.'
+                )
 
         name = LocalParams(self.output).name
         GlobalParams().create_or_update(name, dirname)
@@ -77,7 +81,9 @@ class COrgDeploy(COrgCommand):
 
 {}'''.format(err['message']))
             if err['code'] == -32000:
-                logging.error('The specified wallet has insufficient funds to deploy your Continuous Organization, please send ~0.1eth to {}'.format(wallet.address))
+                logging.error(
+                    'The specified wallet has insufficient funds to deploy your Continuous Organization, please send ~0.1eth to {}'
+                    .format(wallet.address))
             return
 
         logging.info("Great! Your continuous organisation exists!")

--- a/c_org/cli/commands/init.py
+++ b/c_org/cli/commands/init.py
@@ -14,7 +14,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 '''c_org wallet command line'''
 
 import logging
@@ -26,26 +25,29 @@ from c_org.manager import GlobalParams
 
 
 class COrgInit(COrgCommand):
-
     def __init__(self):
-        super().__init__(command_id='init', leaf=True,
-                         description='Initialize a Continuous Organisation')
+        super().__init__(
+            command_id='init',
+            leaf=True,
+            description='Initialize a Continuous Organisation')
         self.subcommand = True
 
     def run(self):
-        self.parser.add_argument('name',
-                                 help='Continuous Organisation\'s name',
-                                 type=str,
-                                 metavar="name")
-        self.parser.add_argument('--output',
-                                  help='Folder to save the continuous organisation',
-                                  type=str)
+        self.parser.add_argument(
+            'name',
+            help='Continuous Organisation\'s name',
+            type=str,
+            metavar="name")
+        self.parser.add_argument(
+            '--output',
+            help='Folder to save the continuous organisation',
+            type=str)
         self.parse_args()
         self.func = self.command_init
         self.run_command()
 
     def command_init(self):
-        directory = self.output if self.output else os.getcwd() 
+        directory = self.output if self.output else os.getcwd()
         global_params = GlobalParams()
         global_params.create_or_update(self.name, directory)
 
@@ -63,4 +65,6 @@ initial_tokens: 1000000 # the number of tokens initially available
         with open(c_org_manager.param_file, 'w+') as f:
             f.write(configs)
 
-        logging.info("Please configure your continuous organisation in the file {}".format(c_org_manager.param_file))
+        logging.info(
+            "Please configure your continuous organisation in the file {}".
+            format(c_org_manager.param_file))

--- a/c_org/cli/commands/revenue.py
+++ b/c_org/cli/commands/revenue.py
@@ -14,7 +14,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 '''storing a revenue'''
 
 import logging
@@ -24,23 +23,23 @@ from c_org import ContinuousOrganisationManager
 from c_org.cli.command import COrgCommand
 from c_org.manager import Vault
 
-class COrgRevenue(COrgCommand):
 
+class COrgRevenue(COrgCommand):
     def __init__(self):
-        super().__init__(command_id='revenue',  leaf=True,
-                         description='Provide some statistics')
+        super().__init__(
+            command_id='revenue',
+            leaf=True,
+            description='Provide some statistics')
         self.subcommand = True
 
-
-
     def run(self):
-        self.parser.add_argument('--revenue',
-                                 help='Revenue to register',
-                                 type=float)
-        self.parser.add_argument('name',
-                                 help='Continuous Organisation\'s name',
-                                 type=str,
-                                 metavar="name")
+        self.parser.add_argument(
+            '--revenue', help='Revenue to register', type=float)
+        self.parser.add_argument(
+            'name',
+            help='Continuous Organisation\'s name',
+            type=str,
+            metavar="name")
         self.func = self.command_revenue
         self.parse_args()
         self.run_command()

--- a/c_org/cli/commands/sell.py
+++ b/c_org/cli/commands/sell.py
@@ -14,7 +14,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 '''c_org sell command line'''
 
 import logging
@@ -22,25 +21,22 @@ from c_org.cli.command import COrgCommand
 from c_org import ContinuousOrganisationManager
 from c_org.manager import Vault
 
-class COrgSell(COrgCommand):
 
+class COrgSell(COrgCommand):
     def __init__(self):
-        super().__init__(command_id='sell',  leaf=True,
-                         description='Sell tokens')
+        super().__init__(
+            command_id='sell', leaf=True, description='Sell tokens')
         self.subcommand = True
 
-
     def run(self):
-        self.parser.add_argument('--wallet',
-                                 help='Wallet\'s sender',
-                                 type=str)
-        self.parser.add_argument('--amount',
-                                 help='Tokens\' amount to send',
-                                 type=float)
-        self.parser.add_argument('name',
-                                 help='Continuous Organisation\'s name',
-                                 type=str,
-                                 metavar="name")
+        self.parser.add_argument('--wallet', help='Wallet\'s sender', type=str)
+        self.parser.add_argument(
+            '--amount', help='Tokens\' amount to send', type=float)
+        self.parser.add_argument(
+            'name',
+            help='Continuous Organisation\'s name',
+            type=str,
+            metavar="name")
         self.func = self.command_sell
         self.parse_args()
         self.run_command()
@@ -53,14 +49,19 @@ class COrgSell(COrgCommand):
         try:
             wallet = vault.find_wallet(name=self.wallet)
         except ValueError:
-            return logging.error('The wallet is not recognized. Add a wallet with the wallet command.')
+            return logging.error(
+                'The wallet is not recognized. Add a wallet with the wallet command.'
+            )
 
         c_org_manager = ContinuousOrganisationManager(self.name)
         if not c_org_manager.is_built():
-            return logging.error('The continuous organisation is not deployed.  Run first `c-org deploy --help`.')
+            return logging.error(
+                'The continuous organisation is not deployed.  Run first `c-org deploy --help`.'
+            )
 
         logging.debug('Selling an amount of {:.3f}'.format(self.amount))
         c_org_manager.sell(self.amount, wallet)
 
         balance = c_org_manager.get_balance(wallet)
-        logging.info("Your sell tokens! Your balance is now {:d}".format(balance))
+        logging.info(
+            "Your sell tokens! Your balance is now {:d}".format(balance))

--- a/c_org/cli/commands/stats.py
+++ b/c_org/cli/commands/stats.py
@@ -14,7 +14,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 '''c_org stats command line'''
 
 import logging
@@ -23,22 +22,23 @@ from c_org.cli.command import COrgCommand
 from c_org import ContinuousOrganisationManager
 from c_org.manager import Vault
 
-class COrgStats(COrgCommand):
 
+class COrgStats(COrgCommand):
     def __init__(self):
-        super().__init__(command_id='stats',  leaf=True,
-                         description='Provide some statistics')
+        super().__init__(
+            command_id='stats',
+            leaf=True,
+            description='Provide some statistics')
         self.subcommand = True
 
-
     def run(self):
-        self.parser.add_argument('--wallet',
-                                 help='Your wallet\'s name',
-                                 type=str)
-        self.parser.add_argument('name',
-                                 help='Continuous Organisation\'s name',
-                                 type=str,
-                                 metavar="name")
+        self.parser.add_argument(
+            '--wallet', help='Your wallet\'s name', type=str)
+        self.parser.add_argument(
+            'name',
+            help='Continuous Organisation\'s name',
+            type=str,
+            metavar="name")
         self.func = self.command_stats
         self.parse_args()
         self.run_command()
@@ -48,12 +48,15 @@ class COrgStats(COrgCommand):
         try:
             wallet = vault.find_wallet(name=self.wallet)
         except ValueError:
-            return logging.error('The wallet is not recognized. Add a wallet with the wallet command.')
+            return logging.error(
+                'The wallet is not recognized. Add a wallet with the wallet command.'
+            )
 
         c_org_manager = ContinuousOrganisationManager(self.name)
         if not c_org_manager.is_built():
-            return logging.error('The continuous organisation is not deployed.  Run first `c-org deploy --help`.')
-
+            return logging.error(
+                'The continuous organisation is not deployed.  Run first `c-org deploy --help`.'
+            )
 
         logging.debug('Retrieving the statistics')
         balance = c_org_manager.get_balance(wallet)

--- a/c_org/cli/commands/wallet.py
+++ b/c_org/cli/commands/wallet.py
@@ -14,7 +14,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 '''c_org wallet command line'''
 
 import logging
@@ -27,53 +26,48 @@ from c_org.manager import Vault
 
 init_ether = 2000000000000000000
 
-class COrgWallet(COrgCommand):
 
+class COrgWallet(COrgCommand):
     def __init__(self):
-        super().__init__(command_id='wallet', leaf=True,
-                         description='Manage a wallet')
+        super().__init__(
+            command_id='wallet', leaf=True, description='Manage a wallet')
         self.subcommand = True
 
     def run(self):
-        subparsers = self.parser.add_subparsers(help="Options to manage wallets")
+        subparsers = self.parser.add_subparsers(
+            help="Options to manage wallets")
         parser_create = subparsers.add_parser('create', help='Create a wallet')
-        parser_create.add_argument('name',
-                                   help='wallet\'s name',
-                                   type=str,
-                                   metavar="name")
+        parser_create.add_argument(
+            'name', help='wallet\'s name', type=str, metavar="name")
         parser_create.set_defaults(func=self.command_create_wallet)
 
         parser_add = subparsers.add_parser('add', help='Add a wallet')
-        parser_add.add_argument('name',
-                                 help='wallet\'s name',
-                                 type=str,
-                                 metavar="name")
-        parser_add.add_argument('private_key',
-                                 help='wallet\'s private key',
-                                 type=str,
-                                 metavar="privateKey")
+        parser_add.add_argument(
+            'name', help='wallet\'s name', type=str, metavar="name")
+        parser_add.add_argument(
+            'private_key',
+            help='wallet\'s private key',
+            type=str,
+            metavar="privateKey")
         parser_add.set_defaults(func=self.command_add_wallet)
 
         parser_rm = subparsers.add_parser('remove', help='Remove a wallet')
-        parser_rm.add_argument('name',
-                                   help='wallet\'s name',
-                                   type=str,
-                                   metavar="name")
+        parser_rm.add_argument(
+            'name', help='wallet\'s name', type=str, metavar="name")
         parser_rm.set_defaults(func=self.command_rm_wallet)
 
-        parser_list = subparsers.add_parser('list', help='Lists stored wallets')
+        parser_list = subparsers.add_parser(
+            'list', help='Lists stored wallets')
         parser_list.set_defaults(func=self.command_list_wallet)
 
-        parser_add_ether = subparsers.add_parser('add_ether', help='Add ether (only for testing purpose)')
-        parser_add_ether.add_argument('name',
-                                      help='wallet\'s name',
-                                      type=str,
-                                      metavar="name")
+        parser_add_ether = subparsers.add_parser(
+            'add_ether', help='Add ether (only for testing purpose)')
+        parser_add_ether.add_argument(
+            'name', help='wallet\'s name', type=str, metavar="name")
         parser_add_ether.set_defaults(func=self.command_add_ether_wallet)
 
         self.parse_args()
         self.run_command()
-
 
     def command_add_wallet(self):
         vault = Vault()
@@ -89,15 +83,15 @@ class COrgWallet(COrgCommand):
         vault.store_wallet(wallet)
         logging.info("The wallet is added.")
 
-
     def command_create_wallet(self):
         vault = Vault()
         if vault.exist_wallet(name=self.name):
             return logging.error("The wallet's name already exists.")
         logging.debug("Creating a wallet with name {}.".format(self.name))
         wallet = vault.create_wallet(self.name)
-        logging.info("The wallet is created. Please add some ethers to its address {}. You can use Metamask for that (see https://youtu.be/-uJjfn4wizE).".format(wallet.address))
-
+        logging.info(
+            "The wallet is created. Please add some ethers to its address {}. You can use Metamask for that (see https://youtu.be/-uJjfn4wizE)."
+            .format(wallet.address))
 
     def command_rm_wallet(self):
         vault = Vault()
@@ -110,7 +104,8 @@ class COrgWallet(COrgCommand):
 
     def command_list_wallet(self):
         for i, wallet in enumerate(Vault().wallets):
-            logging.info("[{}] at {}".format(wallet['name'], wallet['address']))
+            logging.info("[{}] at {}".format(wallet['name'],
+                                             wallet['address']))
 
     def command_add_ether_wallet(self):
         try:

--- a/c_org/cli/core.py
+++ b/c_org/cli/core.py
@@ -14,7 +14,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 '''c_org command line'''
 
 import logging
@@ -24,11 +23,13 @@ import c_org.utils as utils
 from c_org.cli.command import COrgCommand
 import c_org.cli.commands
 
-class Core(COrgCommand):
 
+class Core(COrgCommand):
     def __init__(self):
-        super().__init__(command_id='',  leaf=False,
-                         description='Utility for Continuous Organisation')
+        super().__init__(
+            command_id='',
+            leaf=False,
+            description='Utility for Continuous Organisation')
 
     def parse_args(self):
         self._import_subcommands(c_org.cli.commands)
@@ -38,7 +39,8 @@ class Core(COrgCommand):
         self.parse_args()
 
         if self.debug:
-            logging.basicConfig(level=logging.DEBUG, format='%(levelname)s:%(message)s')
+            logging.basicConfig(
+                level=logging.DEBUG, format='%(levelname)s:%(message)s')
             os.environ['G_MESSAGES_DEBUG'] = 'all'
         else:
             logging.basicConfig(level=logging.INFO, format='%(message)s')

--- a/c_org/manager/__init__.py
+++ b/c_org/manager/__init__.py
@@ -17,16 +17,11 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 '''c_org configuration manager'''
-
 
 from c_org.manager.vault import Vault
 from c_org.manager.global_params import GlobalParams
 from c_org.manager.local_params import LocalParams
 from c_org.manager.base import BaseManager
 
-__all__ = ['Vault',
-           'GlobalParams',
-           'BaseManager',
-           'LocalParams']
+__all__ = ['Vault', 'GlobalParams', 'BaseManager', 'LocalParams']

--- a/c_org/manager/base.py
+++ b/c_org/manager/base.py
@@ -16,7 +16,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 '''c-org base manager'''
 
 import yaml
@@ -25,7 +24,6 @@ import os
 
 
 class BaseManager(object):
-
     def __init__(self, filename=""):
         # _data is assumed to be a dict
         self._data = None

--- a/c_org/manager/global_params.py
+++ b/c_org/manager/global_params.py
@@ -16,16 +16,15 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 '''c-org global params'''
 
 import os
 from c_org.manager.base import BaseManager
 from c_org.utils import get_c_org_path, get_global_params_file
 
+
 class GlobalParams(BaseManager):
     ''' Manage the YAML file ~/.c-org/global.yaml containing global informations on the CO's folders '''
-
 
     @property
     def filename(self):

--- a/c_org/manager/local_params.py
+++ b/c_org/manager/local_params.py
@@ -16,13 +16,12 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 '''c-org parameters manager'''
 
 from c_org.manager.base import BaseManager
 
-class LocalParams(BaseManager):
 
+class LocalParams(BaseManager):
     @property
     def name(self):
         """ Return the path to the continuous organisation's config.yaml file

--- a/c_org/manager/vault.py
+++ b/c_org/manager/vault.py
@@ -16,7 +16,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 '''c-org vault manager'''
 
 import os
@@ -26,10 +25,8 @@ from c_org.manager.base import BaseManager
 from c_org.utils import Wallet, get_c_org_path, get_vault_file
 
 
-
 class Vault(BaseManager):
     ''' Manage the YAML file ~/.c-org/vault.yaml containing the wallets and other securities keys '''
-
 
     @property
     def filename(self):
@@ -77,7 +74,6 @@ class Vault(BaseManager):
             raise ValueError("The wallet\'s name already exists.")
         self.add(wallet, 'wallets')
 
-
     def default_wallet(self):
         '''
         Retrieve the default wallet (the one named `default` or any wallet)
@@ -95,7 +91,6 @@ class Vault(BaseManager):
         if self.exist_wallet(name="default"):
             return self.find_wallet(name="default")
         return self.find_wallet(self.wallets[0]['name'])
-
 
     def find_wallet(self, name="", address="", private_key=""):
         '''
@@ -140,8 +135,6 @@ class Vault(BaseManager):
         self.remove(name, 'name', 'wallets')
 
 
-
-
 if __name__ == "__main__":
     import doctest
     import tempfile
@@ -155,7 +148,8 @@ wallets: []''')
     os.environ['HOME'] = workdir.name
     v = Vault()
     # v.data = {'wallets':[]}
-    doctest.testmod(extraglobs={'v': v,
-                                'wallet': Wallet(name="safe",
-                                                 private_key=private_key)})
+    doctest.testmod(extraglobs={
+        'v': v,
+        'wallet': Wallet(name="safe", private_key=private_key)
+    })
     workdir.cleanup()

--- a/c_org/utils.py
+++ b/c_org/utils.py
@@ -27,13 +27,12 @@ try:
 except:
     import pickle
 
-
-
 rootdir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
 def clean_name(name):
-    return re.sub('\W+','', name.lower())
+    return re.sub('\W+', '', name.lower())
+
 
 def get_c_org_path():
     """ Folder containing the Continuous Organisations' configuration file """
@@ -42,20 +41,28 @@ def get_c_org_path():
     #    os.makedirs(path)
     return path
 
+
 def get_default_path(name):
     name = clean_name(name)
     return os.path.join(get_c_org_path(), name)
 
+
 def get_source_file():
-    return os.path.join(get_c_org_path(), "contracts", "ContinuousOrganisation.sol")
+    return os.path.join(get_c_org_path(), "contracts",
+                        "ContinuousOrganisation.sol")
+
 
 def get_vault_file():
     return os.path.join(get_c_org_path(), "vault.yaml")
 
+
 def get_global_params_file():
     return os.path.join(get_c_org_path(), "global.yaml")
 
+
 hex = "0123456789ABCDEF"
+
+
 def generate_random_private_key():
     ''' Create a random private key
 
@@ -68,15 +75,14 @@ def generate_random_private_key():
 
 
 class Wallet(object):
-
     def __init__(self, name="", address="", private_key=""):
         self.private_key = private_key
         if address:
             self.address = address
         else:
-            self.address = web3.eth.Account.privateKeyToAccount(private_key).address
+            self.address = web3.eth.Account.privateKeyToAccount(
+                private_key).address
         self.name = name if name != "" else self.address
-
 
     @property
     def balance(self):
@@ -94,22 +100,24 @@ class Wallet(object):
         sender = w3.eth.coinbase
         if amount > w3.eth.getBalance(sender):
             raise ValueError("The sender does not have enough coins.")
-        w3.eth.sendTransaction({'from': sender,
-                                  'to': self.address,
-                                  'value': amount})
+        w3.eth.sendTransaction({
+            'from': sender,
+            'to': self.address,
+            'value': amount
+        })
 
     @classmethod
     def from_dict(cls, dict):
-        return cls(dict.get('name'),
-                   dict.get('address'),
-                   dict.get('private_key'))
+        return cls(
+            dict.get('name'), dict.get('address'), dict.get('private_key'))
 
     @staticmethod
     def to_dict(wallet):
         return vars(wallet)
 
     def __repr__(self):
-        return "<class 'Wallet': name={}, address={}, private_key={}>".format(self.name, self.address, self.private_key)
+        return "<class 'Wallet': name={}, address={}, private_key={}>".format(
+            self.name, self.address, self.private_key)
 
 
 class RestrictedUnpickler(pickle.Unpickler):
@@ -125,8 +133,9 @@ class RestrictedUnpickler(pickle.Unpickler):
         if module == "builtins" and name in self.safe_builtins:
             return getattr(builtins, name)
         # Forbid everything else.
-        raise pickle.UnpicklingError("global '%s.%s' is forbidden" %
-                                     (module, name))
+        raise pickle.UnpicklingError(
+            "global '%s.%s' is forbidden" % (module, name))
+
 
 def restricted_unpickle(filename):
     """Helper function analogous to pickle.load()."""
@@ -134,17 +143,16 @@ def restricted_unpickle(filename):
         return RestrictedUnpickler(f).load()
 
 
-
 class BaseError(Exception):
     """Base class for exceptions in this module."""
     pass
+
 
 class ConfigurationError(BaseError):
     """
     Configuration could not be parsed or has otherwise failed to apply
     """
     pass
-
 
 
 if __name__ == "__main__":

--- a/hack/hooks/pre-commit
+++ b/hack/hooks/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+files=$(git ls-files -m)
+[ -n "$files" ] && yapf -i $files

--- a/make.sh
+++ b/make.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+help() {
+	functions=$(echo $(egrep '^\w+\(\)' ./make.sh | cut -d'(' -f1) | sed 's/ / | /g')
+	cat <<-EOF
+	Usage: $0 [$functions]
+	EOF
+}
+
+init() {
+	# add git pre-commit if not present
+	if [ ! -e .git/hooks/pre-commit -a ! -L .git/hooks/pre-commit ]; then
+		ln -s ./hack/hooks/pre-commit .git/hooks/pre-commit
+	fi
+}
+
+[ $# -eq 0 ] && help || "$@"

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,10 @@ class PostDevelopCommand(develop):
         check_files()
         develop.run(self)
 
+
 class PostInstallCommand(install):
     """Post-installation for installation mode."""
+
     def run(self):
         check_files()
         install.run(self)
@@ -42,27 +44,26 @@ def readme():
         return f.read()
 
 
-
-
-setup(name='c_org',
-      version='0.1',
-      url='https://github.com/C-ORG/c-org',
-      long_description=readme(),
-      license='GNU GPL',
-      author='Pierre-Louis Guhur',
-      author_email='pierre-louis.guhur@laposte.net',
-      description='Command line tools to derive Continuous Organisations',
-      packages=find_packages(exclude=['tests', 'doc']),
-      zip_safe=False,
-      include_package_data=True,
-      install_requires = ['PyYaml', 'py-solc', 'web3', 'pytest'],
-      entry_points={
-          'console_scripts': ['c-org=c_org.cli:main'],
-      },
-      cmdclass={
+setup(
+    name='c_org',
+    version='0.1',
+    url='https://github.com/C-ORG/c-org',
+    long_description=readme(),
+    license='GNU GPL',
+    author='Pierre-Louis Guhur',
+    author_email='pierre-louis.guhur@laposte.net',
+    description='Command line tools to derive Continuous Organisations',
+    packages=find_packages(exclude=['tests', 'doc']),
+    zip_safe=False,
+    include_package_data=True,
+    install_requires=['PyYaml', 'py-solc', 'web3', 'pytest'],
+    entry_points={
+        'console_scripts': ['c-org=c_org.cli:main'],
+    },
+    cmdclass={
         'develop': PostDevelopCommand,
         'install': PostInstallCommand,
-      },
-      # setup_requires=['nose>=1.0'],
-      # test_suite='nose.collector'
-      )
+    },
+    # setup_requires=['nose>=1.0'],
+    # test_suite='nose.collector'
+)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -24,13 +24,11 @@ import c_org.utils as utils
 from c_org import ContinuousOrganisationManager
 from c_org.manager import GlobalParams, Vault
 
-
 init_ether = 2000000000000000000
 exe_cli = "c-org"
 
+
 class TestBase(unittest.TestCase):
-
-
     def generate_wallet(self):
         if not self.has_temporary_files():
             self.temp_files()
@@ -52,20 +50,13 @@ class TestBase(unittest.TestCase):
         os.makedirs(c_orgs)
         contracts = os.path.join(c_orgs, "contracts")
         os.makedirs(contracts)
-        contract = os.path.join(rootdir,
-                                "ressources",
-                                ".c-org",
-                                "contracts",
+        contract = os.path.join(rootdir, "ressources", ".c-org", "contracts",
                                 "ContinuousOrganisation.sol")
         shutil.copy(contract, contracts)
-        global_file = os.path.join(rootdir,
-                                   "ressources",
-                                   ".c-org",
+        global_file = os.path.join(rootdir, "ressources", ".c-org",
                                    "global.yaml")
         shutil.copy(global_file, c_orgs)
-        vault_file = os.path.join(rootdir,
-                                  "ressources",
-                                  ".c-org",
+        vault_file = os.path.join(rootdir, "ressources", ".c-org",
                                   "vault.yaml")
         shutil.copy(vault_file, c_orgs)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,7 +42,8 @@ class TestArgs(TestBase):
         self.assertIn(b'--amount', out)
 
     def test_no_command(self):
-        p = subprocess.Popen([exe_cli], stdout=subprocess.PIPE,
+        p = subprocess.Popen([exe_cli],
+                             stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE)
         (out, err) = p.communicate()
         self.assertEqual(out, b'')

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -32,12 +32,12 @@ import c_org.utils as utils
 from c_org.manager import Vault
 
 from web3.auto import w3
+
 # from web3.providers.eth_tester import EthereumTesterProvider
 # w3 = Web3(EthereumTesterProvider(backend=MockBackend()))
 
 
 class TestDeploy(TestBase):
-
     def setUp(self):
         self.generate_c_org()
         self.generate_manager()
@@ -45,12 +45,13 @@ class TestDeploy(TestBase):
 
     def test_deploy(self):
         config_file = os.path.join(self.my_co_path, "config.yaml")
-        sys.argv = [exe_cli, "deploy", config_file, "--wallet", self.wallet.name]
+        sys.argv = [
+            exe_cli, "deploy", config_file, "--wallet", self.wallet.name
+        ]
         main()
         self.assertTrue(os.path.isfile(self.c_org_manager.build_file))
         contract = self.c_org_manager.contract
         self.assertTrue(len(contract.find_functions_by_name('buy')))
-
 
     def test_deploy_default_wallet(self):
         Vault().default_wallet().add_ether(init_ether)
@@ -61,30 +62,27 @@ class TestDeploy(TestBase):
         contract = self.c_org_manager.contract
         self.assertTrue(len(contract.find_functions_by_name('buy')))
 
-
     def test_no_enough_funds(self):
         config_file = os.path.join(self.my_co_path, "config.yaml")
         wallet = Vault().create_wallet('poor-wallet')
         command = [exe_cli, "deploy", config_file, "--wallet", wallet.name]
-        p = subprocess.Popen(command,
-                             stdout=subprocess.PIPE,
-                             stderr=subprocess.PIPE)
+        p = subprocess.Popen(
+            command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         (out, err) = p.communicate()
         self.assertEqual(out, b'')
         self.assertIn(wallet.address.encode('utf-8'), err)
 
 
-
-
 class TestCommandWallet(TestBase):
-
     def setUp(self):
         self.generate_c_org()
         self.generate_manager()
 
     def test_add_wallet(self):
-        sys.argv = [exe_cli] + ["wallet", "add", "test",
-                                utils.generate_random_private_key()]
+        sys.argv = [exe_cli] + [
+            "wallet", "add", "test",
+            utils.generate_random_private_key()
+        ]
         main()
         self.assertTrue(Vault().exist_wallet("test"))
 
@@ -115,7 +113,6 @@ class TestCommandWallet(TestBase):
 
 
 class TestOtherCommands(TestBase):
-
     def setUp(self):
         self.generate_c_org()
         self.generate_manager()
@@ -123,16 +120,20 @@ class TestOtherCommands(TestBase):
         self.c_org_manager.deploy(self.wallet)
 
     def test_buy(self):
-        sys.argv = [exe_cli] + [ "buy", "my-co",  "--wallet", self.wallet.name, "--amount", "0.1"]
+        sys.argv = [exe_cli] + [
+            "buy", "my-co", "--wallet", self.wallet.name, "--amount", "0.1"
+        ]
         main()
 
     def test_sell(self):
         self.c_org_manager.buy(0.1, self.wallet)
-        sys.argv = [exe_cli] + ["sell", "my-co", "--wallet", self.wallet.name, "--amount", "1"]
+        sys.argv = [exe_cli] + [
+            "sell", "my-co", "--wallet", self.wallet.name, "--amount", "1"
+        ]
         main()
 
     def test_revenue(self):
-        sys.argv = [exe_cli] + ["revenue",  "my-co", "--revenue", "0.1"]
+        sys.argv = [exe_cli] + ["revenue", "my-co", "--revenue", "0.1"]
         main()
 
     def test_stats(self):
@@ -141,7 +142,5 @@ class TestOtherCommands(TestBase):
         main()
 
 
-
-
 if __name__ == '__main__':
-   unittest.main()
+    unittest.main()

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -38,6 +38,7 @@ from .test_base import TestBase
 exe_cli = "c-org"
 init_ether = 2000000000000000000
 
+
 def sed(pattern, replace, source):
     """ Copy the sed bash function. Details on  https://stackoverflow.com/a/40843600/4986615 """
     fin = open(source, 'r')
@@ -50,7 +51,6 @@ def sed(pattern, replace, source):
 
 
 class TestNewIssuer(TestBase):
-
     def setUp(self):
         # we assume Edith has correctly installed the utility
         self.generate_c_org()
@@ -65,10 +65,13 @@ class TestNewIssuer(TestBase):
         # Edith creates a new folder, jumps on it and downloads the config.yaml given in the repository.
         os.makedirs("my-co")
         os.chdir("my-co")
-        urlretrieve ("https://raw.githubusercontent.com/C-ORG/c-org/master/config.yaml", "config.yaml")
+        urlretrieve(
+            "https://raw.githubusercontent.com/C-ORG/c-org/master/config.yaml",
+            "config.yaml")
 
         # Edith edits the config.yaml
-        sed("summary: ''", "summary: 'My CO is the best in the world!'", "config.yaml")
+        sed("summary: ''", "summary: 'My CO is the best in the world!'",
+            "config.yaml")
 
         # Edith creates a wallet and adds Ether on it
         sys.argv = [exe_cli] + ["wallet", "create", "edith-wallet"]
@@ -82,20 +85,25 @@ class TestNewIssuer(TestBase):
         self.assertEqual(init_ether, wallet.balance)
 
         # Edith deploys her continuous organisation
-        sys.argv = [exe_cli] + ["deploy", "config.yaml", "--wallet", wallet.name, "--output", os.getcwd()]
+        sys.argv = [exe_cli] + [
+            "deploy", "config.yaml", "--wallet", wallet.name, "--output",
+            os.getcwd()
+        ]
         main()
         self.assertTrue(os.path.isfile("build.yaml"))
 
         # Edith buys and sells some tokens
-        sys.argv = [exe_cli] + ["buy", "my-co", "--wallet", wallet.name, "--amount", "1"]
+        sys.argv = [exe_cli] + [
+            "buy", "my-co", "--wallet", wallet.name, "--amount", "1"
+        ]
         main()
         self.assertTrue(init_ether > wallet.balance)
 
-        sys.argv = [exe_cli] + ["sell", "my-co", "--wallet", wallet.name, "--amount", "1"]
+        sys.argv = [exe_cli] + [
+            "sell", "my-co", "--wallet", wallet.name, "--amount", "1"
+        ]
         main()
 
 
-
-
 if __name__ == '__main__':
-   unittest.main()
+    unittest.main()

--- a/tests/test_global_param.py
+++ b/tests/test_global_param.py
@@ -27,7 +27,6 @@ from c_org.manager import GlobalParams
 from .test_base import TestBase
 
 
-
 class TestGlobalParam(TestBase):
     '''Param mixin tests'''
 
@@ -67,7 +66,6 @@ class TestGlobalParam(TestBase):
         self.g.data = {'c-orgs': []}
         self.g.save()
         self.assertFalse(self.g.exists('My C-Org', 'name', 'c-orgs'))
-
 
 
 if __name__ == '__main__':

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -24,9 +24,7 @@ import c_org.utils as utils
 from .test_base import TestBase
 
 
-
 class TestContinuousOrganisationManager(TestBase):
-
     def setUp(self):
         self.generate_c_org()
         self.generate_manager()
@@ -35,9 +33,9 @@ class TestContinuousOrganisationManager(TestBase):
     def test_local_params(self):
         self.assertIn('slope', self.c_org_manager.params.data)
         self.assertIn('version', self.c_org_manager.params.data)
-        self.assertEqual(1000000, self.c_org_manager.params.get('initial_tokens'))
+        self.assertEqual(1000000,
+                         self.c_org_manager.params.get('initial_tokens'))
         self.assertNotIn('c-org', self.c_org_manager.params.data)
-
 
     def test_generate_ui(self):
         pass
@@ -46,9 +44,11 @@ class TestContinuousOrganisationManager(TestBase):
         self.c_org_manager.deploy(self.wallet)
         abi = self.c_org_manager.interface.get('abi')
         functions = [i['name'] for i in abi if i['type'] == 'function']
-        self.assertEqual(len(functions), len(self.c_org_manager.contract.all_functions()))
+        self.assertEqual(
+            len(functions), len(self.c_org_manager.contract.all_functions()))
         self.assertIn('buy', functions)
-        self.assertNotIn('UpdateTokens', functions) # this is an event not a function
+        self.assertNotIn('UpdateTokens',
+                         functions)  # this is an event not a function
 
     def test_deploy(self):
         self.c_org_manager.deploy(self.wallet)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,6 +26,7 @@ import c_org.utils as utils
 from .test_base import TestBase
 import pickle
 
+
 class TestUtils(TestBase):
     '''Utils tests'''
 

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -57,15 +57,18 @@ class TestVault(TestBase):
 
     def test_store_wallet_dict(self):
         self.assertFalse(self.v.exist_wallet('dict-wallet'))
-        wallet = {'name': "dict-wallet",
-                  'private_key': utils.generate_random_private_key()}
+        wallet = {
+            'name': "dict-wallet",
+            'private_key': utils.generate_random_private_key()
+        }
         self.v.store_wallet(wallet)
         self.assertTrue(self.v.exist_wallet('dict-wallet'))
 
     def test_store_wallet(self):
         self.assertFalse(self.v.exist_wallet('wallet-wallet'))
-        wallet = utils.Wallet(name="wallet-wallet",
-                              private_key=utils.generate_random_private_key())
+        wallet = utils.Wallet(
+            name="wallet-wallet",
+            private_key=utils.generate_random_private_key())
         self.v.store_wallet(wallet)
         self.assertTrue(self.v.exist_wallet('wallet-wallet'))
 
@@ -78,7 +81,6 @@ class TestVault(TestBase):
         self.v.data['wallets'] = []
         self.v.save()
         self.assertFalse(self.v.exist_wallet('my-wallet'))
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This patch formats all python code with google's yapf (`pip3 install yapf`)
and adds a pre-commit hook that can be set up with a make.sh script:

```
$ ./make.sh init
```

Signed-off-by: Tibor Vass <teabee89@gmail.com>